### PR TITLE
remove ruby testing for 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
@@ -26,7 +25,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## Breaking Change
+- removed ruby 1.9 testing as its really not supported anymore (@majormoses)
+
 ## [0.1.0] - 2016-08-16
 ## Changed
 - Updated sensu-plugin dependency from `= 1.2.0` to `~> 1.2.0`


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
Remove unsupported ruby 1.9 testing (tests were breaking anyways)
#### Known Compatablity Issues
We have not supported ruby 1.9 for a while.

