### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### General
 
-- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
+- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 - [ ] Update README with any necessary configuration snippets
 
@@ -25,4 +25,3 @@
 #### Purpose
 
 #### Known Compatability Issues
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418 (@majormoses)
+
+### Breaking Changes
+- removed ruby `< 2.1` support (@majormoses)
+
+### Fixed
+- metrics-zen.rb: fixed a bug due to using single quotes where string interpolation is necessary (@majormoses)
+
+### Changed
+- updated changelog guidelines location (@majormoses)
 
 ## [2.0.0] 2017-07-04
 ### Added

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require 'bundler/gem_tasks'
 require 'github/markup'
+require 'English'
 require 'redcarpet'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
@@ -7,9 +8,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +36,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/metrics-xen.rb
+++ b/bin/metrics-xen.rb
@@ -39,14 +39,15 @@ class XenGraphite < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Metric naming scheme, text to prepend to metric',
          short: '-s SCHEME',
          long: '--scheme SCHEME',
-         default: '#{Socket.gethostbyname("#{Socket.gethostname}").first}.xen'
+         default: "#{Socket.gethostbyname(Socket.gethostname).first}.xen"
 
   def run
     xen = metrics_hash
     xm = xm_hash
     xencount = xenservers
     i = 0
-    xen.each do |_k, v|
+    # TODO: come back and refactor me
+    xen.each_value do |v| # rubocop:disable Metrics/BlockLength
       result = v.split(' ')
       metrics = {
         :"#{xencount[i]}" => {

--- a/sensu-plugins-xen.gemspec
+++ b/sensu-plugins-xen.gemspec
@@ -9,14 +9,14 @@ else
   require_relative 'lib/sensu-plugins-xen'
 end
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
 
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for working with xen'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-xen'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => '',
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
 
   s.summary                = 'Sensu plugins for working with xen'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Breaking Changes:
- removed ruby `< 2.1` support

Misc:
- appeased the cops
- fixed bug with single quotes where interpolation is needed
- update changelog guidelines link

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Resolve CVE, see parent issue for details

#### Known Compatibility Issues
Removes ruby `< 2.1` support
